### PR TITLE
Corrected transaction reference getters

### DIFF
--- a/src/Message/CompletePurchaseResponse.php
+++ b/src/Message/CompletePurchaseResponse.php
@@ -13,10 +13,15 @@ class CompletePurchaseResponse extends AbstractResponse
     {
         return isset($this->data['status']) && $this->data['status'] == 'APPROVED';
     }
+    
+    public function getTransactionId()
+    {
+        return isset($this->data['oid']) ? $this->data['oid'] : null;
+    }
 
     public function getTransactionReference()
     {
-        return isset($this->data['oid']) ? $this->data['oid'] : null;
+        return isset($this->data['refnumber']) ? $this->data['refnumber'] : null;
     }
 
     public function getMessage()

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -50,7 +50,7 @@ class GatewayTest extends GatewayTestCase
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertEquals('abc123456', $response->getTransactionReference());
+        $this->assertEquals('abc123456', $response->getTransactionId());
         $this->assertSame('APPROVED', $response->getMessage());
     }
 
@@ -90,7 +90,7 @@ class GatewayTest extends GatewayTestCase
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertEquals('abc1234', $response->getTransactionReference());
+        $this->assertEquals('abc1234', $response->getTransactionId());
         $this->assertSame('DECLINED', $response->getMessage());
     }
 }

--- a/tests/Message/CompletePurchaseResponseTest.php
+++ b/tests/Message/CompletePurchaseResponseTest.php
@@ -22,7 +22,7 @@ class CompletePurchaseResponseTest extends TestCase
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertSame('abc123456', $response->getTransactionReference());
+        $this->assertSame('abc123456', $response->getTransactionId());
         $this->assertSame('APPROVED', $response->getMessage());
     }
 
@@ -42,7 +42,7 @@ class CompletePurchaseResponseTest extends TestCase
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertSame('abc1234', $response->getTransactionReference());
+        $this->assertSame('abc1234', $response->getTransactionId());
         $this->assertSame('DECLINED', $response->getMessage());
     }
 }


### PR DESCRIPTION
Added getTransactionId() method and corrected what getTransactionReference() returns.

OmniPay convention states that transactionId is 'our' reference (which is held in 'oid') and transactionReference should be 'their' ID (which is held in 'refnumber').
