### PR TITLE
Added hosteddataid, amongst other things

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -37,9 +37,19 @@ class PurchaseRequest extends AbstractRequest
         return $this->getParameter('sharedSecret');
     }
 
+    public function setHostedDataId($value)
+    {
+        return $this->setParameter('hostedDataId', $value);
+    }
+
+    public function getHostedDataId()
+    {
+        return $this->getParameter('hostedDataId');
+    }
+
     public function getData()
     {
-        $this->validate('amount', 'card');
+        $this->validate('amount');
 
         $data = array();
         $data['storename'] = $this->getStoreId();
@@ -53,15 +63,26 @@ class PurchaseRequest extends AbstractRequest
         $data['full_bypass'] = 'true';
         $data['oid'] = $this->getParameter('transactionId');
 
-        $this->getCard()->validate();
+        // Card is only required if no hosteddataid (saved 'data vault' card)
+        if (is_null($this->getHostedDataId())) {
+            $this->validate('card');
+        }
 
-        $data['cardnumber'] = $this->getCard()->getNumber();
-        $data['cvm'] = $this->getCard()->getCvv();
-        $data['expmonth'] = $this->getCard()->getExpiryDate('m');
-        $data['expyear'] = $this->getCard()->getExpiryDate('y');
+        // If a card is passed, validate it
+        if (!is_null($this->getCard())) {
+
+            $this->getCard()->validate();
+
+            $data['cardnumber'] = $this->getCard()->getNumber();
+            $data['cvm'] = $this->getCard()->getCvv();
+            $data['expmonth'] = $this->getCard()->getExpiryDate('m');
+            $data['expyear'] = $this->getCard()->getExpiryDate('y');
+        }
 
         $data['responseSuccessURL'] = $this->getParameter('returnUrl');
         $data['responseFailURL'] = $this->getParameter('returnUrl');
+
+        $data['hosteddataid'] = $this->getHostedDataId();
 
         return $data;
     }

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -77,10 +77,30 @@ class PurchaseRequest extends AbstractRequest
             $data['cvm'] = $this->getCard()->getCvv();
             $data['expmonth'] = $this->getCard()->getExpiryDate('m');
             $data['expyear'] = $this->getCard()->getExpiryDate('y');
+
+            $data['bname'] = $this->getCard()->getBillingName();
+            $data['baddr1'] = $this->getCard()->getBillingAddress1();
+            $data['baddr2'] = $this->getCard()->getBillingAddress2();
+            $data['bcity'] = $this->getCard()->getBillingCity();
+            $data['bstate'] = $this->getCard()->getBillingState();
+            $data['bcountry'] = $this->getCard()->getBillingCountry();
+            $data['bzip'] = $this->getCard()->getBillingPostcode();
+
+            $data['sname'] = $this->getCard()->getShippingName();
+            $data['saddr1'] = $this->getCard()->getShippingAddress1();
+            $data['saddr2'] = $this->getCard()->getShippingAddress2();
+            $data['scity'] = $this->getCard()->getShippingCity();
+            $data['sstate'] = $this->getCard()->getShippingState();
+            $data['scountry'] = $this->getCard()->getShippingCountry();
+            $data['szip'] = $this->getCard()->getShippingPostcode();
+
+            $data['phone'] = $this->getCard()->getPhone();
+            $data['email'] = $this->getCard()->getEmail();
         }
 
         $data['responseSuccessURL'] = $this->getParameter('returnUrl');
         $data['responseFailURL'] = $this->getParameter('returnUrl');
+
 
         $data['hosteddataid'] = $this->getHostedDataId();
 

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -77,7 +77,7 @@ class PurchaseRequest extends AbstractRequest
         // If no hosted data, or a number is passed, validate the whole card
         if (is_null($this->getHostedDataId()) || !is_null($this->getCard()->getNumber())) {
             $this->getCard()->validate();
-        } else if (is_null($this->getCard()->getCvv())) {
+        } elseif (is_null($this->getCard()->getCvv())) {
             // Else we only require the cvv when using hosted data
             throw new InvalidCreditCardException("The CVV parameter is required when using hosteddataid");
         }

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -47,6 +47,16 @@ class PurchaseRequest extends AbstractRequest
         return $this->getParameter('hostedDataId');
     }
 
+    public function setCustomerId($value)
+    {
+        return $this->setParameter('customerId', $value);
+    }
+
+    public function getCustomerId()
+    {
+        return $this->getParameter('customerId');
+    }
+
     public function getData()
     {
         $this->validate('amount');
@@ -101,6 +111,7 @@ class PurchaseRequest extends AbstractRequest
         $data['responseSuccessURL'] = $this->getParameter('returnUrl');
         $data['responseFailURL'] = $this->getParameter('returnUrl');
 
+        $data['customerid'] = $this->getCustomerId();
 
         $data['hosteddataid'] = $this->getHostedDataId();
 

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -19,7 +19,8 @@ class GatewayTest extends GatewayTestCase
             'returnUrl' => 'https://www.example.com/return',
             'card' => $this->getValidCard(),
             'transactionId' => 'abc123',
-            'currency' => 'GBP'
+            'currency' => 'GBP',
+            'customerId' => 54321
         );
     }
 


### PR DESCRIPTION
Added optional hosteddataid field outlined in the Connect EMEA Integration guide:
https://www.firstdata.com/downloads/marketing-merchant/emea_integrationguide_connect_2_0.pdf
Page 14, section 9

This allows use of the data vault, saving cards against that id, meaning that future payment no longer require the card data (other than CVV).
Validation has been updated for this, with unit tests to simulate the new hosteddataid only route.

Further optional fields for data visible in the virtual terminal have been added too.

This change is fully backwards compatible.
The only changes to the original unit tests are for removing duplicates and for code coverage improvements.
