### PR TITLE
Transarmor Token Support for purchase() and authorize()

### DIFF
--- a/runtests-win.sh
+++ b/runtests-win.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+#
+# Command line runner for unit tests for composer projects
+# (c) Del 2015 http://www.babel.com.au/
+# No Rights Reserved
+#
+
+#
+# Ensure that dependencies are installed (including codeception and phpunit)
+#
+if [ -f composer.lock ]; then
+    composer install
+else
+    composer update
+fi
+
+#
+# Clean up after any previous test runs
+#
+mkdir -p documents
+rm -rf documents/coverage-html-new
+rm -f documents/coverage.xml
+
+#
+# Run phpunit
+#
+vendor/bin/phpunit --coverage-html documents/coverage-html-new --coverage-clover documents/coverage.xml --log-junit documents/phpunit.xml
+
+if [ -d documents/coverage-html-new ]; then
+  rm -rf documents/coverage-html
+  mv documents/coverage-html-new documents/coverage-html
+fi
+

--- a/src/Message/PayeezyPurchaseRequest.php
+++ b/src/Message/PayeezyPurchaseRequest.php
@@ -63,7 +63,7 @@ namespace Omnipay\FirstData\Message;
  *     'cardReference'            => $yourStoredToken,
  *     'clientIp'                 => $_SERVER['REMOTE_ADDR'],
  *     'card'                     => $card,
- *     'tokenCardType'			  => 'visa', // MUST BE VALID CONST FROM \omnipay\common\CreditCard
+ *     'tokenCardType'              => 'visa', // MUST BE VALID CONST FROM \omnipay\common\CreditCard
  * ));
  *
  *
@@ -87,42 +87,42 @@ class PayeezyPurchaseRequest extends PayeezyAbstractRequest
 
         $this->validate('amount', 'card');
 
-		$data['amount'] = $this->getAmount();
-		$data['currency_code'] = $this->getCurrency();
-		$data['reference_no'] = $this->getTransactionId();
+        $data['amount'] = $this->getAmount();
+        $data['currency_code'] = $this->getCurrency();
+        $data['reference_no'] = $this->getTransactionId();
 
-		// add credit card details
-		if($this->getCardReference()) {
-			$this->validate('tokenCardType');
-			$data['transarmor_token'] = $this->getCardReference();
-			$data['credit_card_type'] = $this->getTokenCardType();
-		} else {
-			$data['credit_card_type'] = self::getCardType($this->getCard()->getBrand());
-			$data['cc_number'] = $this->getCard()->getNumber();
-			$data['cc_verification_str2'] = $this->getCard()->getCvv();
-			$data['cc_verification_str1'] = $this->getAVSHash();
-			$data['cvd_presence_ind'] = 1;
-			$data['cvd_code'] = $this->getCard()->getCvv();
-		}
-		$data['cardholder_name'] = $this->getCard()->getName();
-		$data['cc_expiry'] = $this->getCard()->getExpiryDate('my');
+        // add credit card details
+        if ($this->getCardReference()) {
+            $this->validate('tokenCardType');
+            $data['transarmor_token'] = $this->getCardReference();
+            $data['credit_card_type'] = $this->getTokenCardType();
+        } else {
+            $data['credit_card_type'] = self::getCardType($this->getCard()->getBrand());
+            $data['cc_number'] = $this->getCard()->getNumber();
+            $data['cc_verification_str2'] = $this->getCard()->getCvv();
+            $data['cc_verification_str1'] = $this->getAVSHash();
+            $data['cvd_presence_ind'] = 1;
+            $data['cvd_code'] = $this->getCard()->getCvv();
+        }
+        $data['cardholder_name'] = $this->getCard()->getName();
+        $data['cc_expiry'] = $this->getCard()->getExpiryDate('my');
 
 
-		$data['client_ip'] = $this->getClientIp();
-		$data['client_email'] = $this->getCard()->getEmail();
-		$data['language'] = strtoupper($this->getCard()->getCountry());
+        $data['client_ip'] = $this->getClientIp();
+        $data['client_email'] = $this->getCard()->getEmail();
+        $data['language'] = strtoupper($this->getCard()->getCountry());
 
-		return $data;
+        return $data;
 
     }
 
-	public function getTokenCardType()
+    public function getTokenCardType()
+    {
+        return $this->getParameter('tokenCardType');
+    }
+
+    public function setTokenCardType($value)
 	{
-		return $this->getParameter('tokenCardType');
-	}
-
-	public function setTokenCardType($value) {
-		return $this->setParameter('tokenCardType', $value);
-	}
-
+        return $this->setParameter('tokenCardType', $value);
+    }
 }

--- a/src/Message/PayeezyPurchaseRequest.php
+++ b/src/Message/PayeezyPurchaseRequest.php
@@ -122,7 +122,7 @@ class PayeezyPurchaseRequest extends PayeezyAbstractRequest
     }
 
     public function setTokenCardType($value)
-	{
+    {
         return $this->setParameter('tokenCardType', $value);
     }
 }

--- a/src/Message/PayeezyPurchaseRequest.php
+++ b/src/Message/PayeezyPurchaseRequest.php
@@ -93,6 +93,7 @@ class PayeezyPurchaseRequest extends PayeezyAbstractRequest
 
 		// add credit card details
 		if($this->getCardReference()) {
+			$this->validate('tokenCardType');
 			$data['transarmor_token'] = $this->getCardReference();
 			$data['credit_card_type'] = $this->getTokenCardType();
 		} else {


### PR DESCRIPTION
I'm not really sure if how I did this fits with the "way things are done" around here, but it works, its a needed feature so if its acceptable please merge it or if not, feel free to re-implement it the way you want it implemented.

Basically I just had to add getTokenCardType() and setTokenCardType() to `PayeezyPurchaseRequest`, which allows the user to supply a "tokenCardType" parameter when calling `$gateway->purchase()` or `$gateway->authorize()`. tokenCardType is required and must match a valid card type found in `\omnipay\common\CreditCard`. The user must also supply the built in `cardReference` parameter with the desired card token.

The `CreditCard` parameter must contain the cardholder name supplied by which ever field works for the user `name` `billingName` or whatever firstName / lastName fields they want. The card Expiration date must also be supplied. 

There is a usage example added to the comments in `PayeezyPurchaseRequest.php`

This fixes https://github.com/thephpleague/omnipay-firstdata/issues/9