### PR TITLE
Add support to PHP 7.3 and PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "aphixsoftware/omnipay-firstdata",
+    "name": "omnipay/firstdata",
     "type": "library",
     "description": "First Data driver for the Omnipay payment processing library",
     "keywords": [
@@ -11,7 +11,7 @@
         "pay",
         "payment"
     ],
-    "homepage": "https://github.com/aphixsoftware/omnipay-firstdata",
+    "homepage": "https://github.com/thephpleague/omnipay-firstdata",
     "license": "MIT",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "omnipay/firstdata",
+    "name": "aphixsoftware/omnipay-firstdata",
     "type": "library",
     "description": "First Data driver for the Omnipay payment processing library",
     "keywords": [
@@ -11,7 +11,7 @@
         "pay",
         "payment"
     ],
-    "homepage": "https://github.com/thephpleague/omnipay-firstdata",
+    "homepage": "https://github.com/aphixsoftware/omnipay-firstdata",
     "license": "MIT",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -27,17 +27,21 @@
         "psr-4": { "Omnipay\\FirstData\\" : "src/" }
     },
     "require": {
-        "php": "^5.6|^7",
-        "omnipay/common": "~3.0",
-        "php-http/guzzle6-adapter": "^1.1"
+        "php": "^7.3|^8",
+        "omnipay/common": "~3.1"
     },
     "require-dev": {
-        "omnipay/tests": "~3.1"
+        "omnipay/tests": "^4"
     },
     "extra": {
         "branch-alias": {
             "dev-master": "3.0.x-dev"
         }
     },
-    "prefer-stable": true
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,15 +28,10 @@
     },
     "require": {
         "php": "^7.3|^8",
-        "omnipay/common": "~3.1"
+        "omnipay/common": "^3.0"
     },
     "require-dev": {
         "omnipay/tests": "^4"
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "3.0.x-dev"
-        }
     },
     "prefer-stable": true,
     "config": {

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -6,7 +6,10 @@ use Omnipay\Tests\GatewayTestCase;
 
 class GatewayTest extends GatewayTestCase
 {
-    public function setUp()
+    /** @var array */
+    protected $options = [];
+    
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -31,7 +34,7 @@ class GatewayTest extends GatewayTestCase
         $this->assertFalse($response->isSuccessful());
         $this->assertTrue($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
-        $this->assertContains('ipg-online.com/connect/gateway/processing', $response->getRedirectUrl());
+        $this->assertTrue(strpos($response->getRedirectUrl(), 'ipg-online.com/connect/gateway/processing') !== false);
     }
 
     public function testCompletePurchaseSuccess()
@@ -56,9 +59,6 @@ class GatewayTest extends GatewayTestCase
         $this->assertNull($response->getTransactionReference());
     }
 
-    /**
-     * @expectedException \Omnipay\Common\Exception\InvalidResponseException
-     */
     public function testCompletePurchaseInvalidCallbackPassword()
     {
         $this->getHttpRequest()->request->replace(
@@ -71,6 +71,8 @@ class GatewayTest extends GatewayTestCase
                 'approval_code' => 'Y:136432:0013649958:PPXM:0015'
             )
         );
+
+        $this->expectException(\Omnipay\Common\Exception\InvalidResponseException::class);
 
         $response = $this->gateway->completePurchase($this->options)->send();
     }
@@ -119,8 +121,6 @@ class GatewayTest extends GatewayTestCase
      *
      * Simulates paying using a saved card, rather than passing card data
      * This example is checking that an exception occurs if missing the CVV number
-     *
-     * @expectedException \Omnipay\Common\Exception\InvalidCreditCardException
      */
     public function testPurchaseWithHostedDataIdAndWithoutCardFailsWithoutCVV()
     {
@@ -130,6 +130,8 @@ class GatewayTest extends GatewayTestCase
         unset($this->options['card']['number']);
         // Also remove required cvv to check for error
         unset($this->options['card']['cvv']);
+
+        $this->expectException(\Omnipay\Common\Exception\InvalidCreditCardException::class);
 
         $response = $this->gateway->purchase($this->options)->send();
 
@@ -163,13 +165,13 @@ class GatewayTest extends GatewayTestCase
      * testPurchaseErrorWhenMissingHostedDataIdAndWithoutCardNumber.
      *
      * Simulates neither hosteddataid or card data being passed, should be caught in app.
-     *
-     * @expectedException \Omnipay\Common\Exception\InvalidCreditCardException
      */
     public function testPurchaseErrorWhenMissingHostedDataIdAndWithoutCardNumber()
     {
         unset($this->options['card']);
         $this->options['card']['cvv'] = 123;
+
+        $this->expectException(\Omnipay\Common\Exception\InvalidCreditCardException::class);
 
         $response = $this->gateway->purchase($this->options)->send();
 

--- a/tests/Message/WebservicePurchaseRequestTest.php
+++ b/tests/Message/WebservicePurchaseRequestTest.php
@@ -33,7 +33,7 @@ class WebservicePurchaseRequestTest extends TestCase
         // Test request internals
         $curl = $request->buildCurlClient();
 
-        if (phpversion() >= '8.0.0') {
+        if (version_compare(PHP_VERSION, '8.0.0', '>=')) {
             $this->assertInstanceOf(\CurlHandle::class, $curl);
         } else {
             $this->assertIsResource($curl);

--- a/tests/Message/WebservicePurchaseRequestTest.php
+++ b/tests/Message/WebservicePurchaseRequestTest.php
@@ -32,7 +32,12 @@ class WebservicePurchaseRequestTest extends TestCase
 
         // Test request internals
         $curl = $request->buildCurlClient();
-        $this->assertTrue(is_resource($curl));
+
+        if (phpversion() >= '8.0.0') {
+            $this->assertInstanceOf(\CurlHandle::class, $curl);
+        } else {
+            $this->assertIsResource($curl);
+        }
 
         $endpoint = $request->getEndpoint();
         $this->assertEquals('https://ws.merchanttest.firstdataglobalgateway.com:443/fdggwsapi/services', $endpoint);

--- a/tests/PayeezyGatewayTest.php
+++ b/tests/PayeezyGatewayTest.php
@@ -12,7 +12,7 @@ class PayeezyGatewayTest extends GatewayTestCase
     /** @var  array */
     protected $options;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/WebserviceGatewayTest.php
+++ b/tests/WebserviceGatewayTest.php
@@ -12,7 +12,7 @@ class WebserviceGatewayTest extends GatewayTestCase
     /** @var  array */
     protected $options;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
This PR updates the requirements on composer.json to support PHP 8.

All tests passing on both PHP 7.3 and PHP 8.